### PR TITLE
build: try to compress debug section

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1402,8 +1402,8 @@ endif()
 # use_debug_fission: whether to use split DWARF debug info files. This can
 # reduce link time significantly.
 cmake_dependent_option(
-  USE_DEBUG_FISSION "Build with debug fission" ON
-  "NOT ANDROID; NOT APPLE; NOT MSVC; USE_LLD" OFF)
+  USE_DEBUG_FISSION "Build with debug fission" OFF
+  "NOT APPLE; NOT MSVC" OFF)
 
 # ld.lld: error: <unknown>:0: A dwo section may not contain relocations
 if (USE_LLD AND (OS_RISCV64 OR OS_RISCV32 OR OS_LOONGARCH64))
@@ -1420,10 +1420,13 @@ if (USE_DEBUG_FISSION)
 endif()
 
 cmake_dependent_option(
-  USE_COMPRESS_DEBUG_SECTIONS "Build with compress debug section" ON
+  USE_COMPRESS_DEBUG_SECTIONS "Build with compress debug section" OFF
   "NOT MSVC; NOT APPLE" OFF)
 
-if (USE_COMPRESS_DEBUG_SECTIONS)
+if ((USE_COMPRESS_DEBUG_SECTIONS AND USE_LLD) OR USE_MOLD)
+  add_link_options(-Wl,--compress-debug-sections=zstd)
+  list(APPEND YASS_APP_FEATURES "debug compressed (zstd)")
+elseif(USE_COMPRESS_DEBUG_SECTIONS)
   # command below is the same thing with '-gz'
   # add_link_options(-Wl,--compress-debug-sections=zlib)
   add_link_options(-gz)

--- a/tools/build.go
+++ b/tools/build.go
@@ -1775,7 +1775,7 @@ func gnuStripBinary(binName string, dbgName string) {
 	// create a file containing the debugging info.
 	// FIXME it looks like mingw's --compress-debug-sections isn't implemented
 	// see https://github.com/mstorsjo/llvm-mingw/issues/553
-	cmdRun([]string{objcopy, "--only-keep-debug", "--compress-debug-sections=zlib", binName, dbgName}, false)
+	cmdRun([]string{objcopy, "--only-keep-debug", "--compress-debug-sections=zstd", binName, dbgName}, false)
 	// stripped executable.
 	cmdRun([]string{objcopy, "--strip-debug", binName}, false)
 	// to add a link to the debugging info into the stripped executable.

--- a/tools/build.go
+++ b/tools/build.go
@@ -1773,7 +1773,9 @@ func gnuStripBinary(binName string, dbgName string) {
 		objcopy = "objcopy"
 	}
 	// create a file containing the debugging info.
-	cmdRun([]string{objcopy, "--only-keep-debug", binName, dbgName}, false)
+	// FIXME it looks like mingw's --compress-debug-sections isn't implemented
+	// see https://github.com/mstorsjo/llvm-mingw/issues/553
+	cmdRun([]string{objcopy, "--only-keep-debug", "--compress-debug-sections=zlib", binName, dbgName}, false)
 	// stripped executable.
 	cmdRun([]string{objcopy, "--strip-debug", binName}, false)
 	// to add a link to the debugging info into the stripped executable.
@@ -1814,12 +1816,12 @@ func postStateStripBinaries() {
 			name := entry.Name()
 			iname := strings.ToLower(name)
 			if strings.HasSuffix(iname, ".so") || strings.HasSuffix(iname, ".dll") {
-				gnuStripBinary(filepath.Join(buildDir, name), basename(name)+".dbg")
+				gnuStripBinary(name, name+".dbg")
 			}
 		}
 
 		// strip main binary
-		gnuStripBinary(getAppName(), APPNAME+".dbg")
+		gnuStripBinary(getAppName(), getAppName()+".dbg")
 
 		// strip test binary
 		if buildTestFlag {
@@ -1827,7 +1829,7 @@ func postStateStripBinaries() {
 			if systemNameFlag == "mingw" {
 				binName = "yass_test.exe"
 			}
-			gnuStripBinary(filepath.Join(buildDir, binName), "yass_test.dbg")
+			gnuStripBinary(binName, binName+".dbg")
 		}
 		// strip benchmark binary
 		if buildBenchmarkFlag {
@@ -1835,36 +1837,36 @@ func postStateStripBinaries() {
 			if systemNameFlag == "mingw" {
 				binName = "yass_benchmark.exe"
 			}
-			gnuStripBinary(filepath.Join(buildDir, binName), "yass_benchmark.dbg")
+			gnuStripBinary(binName, binName+".dbg")
 		}
 	} else if systemNameFlag == "darwin" {
 		// strip dependent dll files
-		frameworkPath := filepath.Join(buildDir, getAppName(), "Contents", "Frameworks")
+		frameworkPath := filepath.Join(getAppName(), "Contents", "Frameworks")
 		entries, _ := ioutil.ReadDir(frameworkPath)
 		for _, entry := range entries {
 			name := entry.Name()
 			iname := strings.ToLower(name)
 			if strings.HasSuffix(iname, ".dylib") {
-				darwinStripBinary(filepath.Join(frameworkPath, name), basename(name)+".dSYM")
+				darwinStripBinary(filepath.Join(frameworkPath, name), name+".dSYM")
 			}
 		}
 
 		// strip main binary
-		execPath := filepath.Join(buildDir, getAppName(), "Contents", "MacOS", APPNAME)
-		darwinStripBinary(execPath, APPNAME+".dSYM")
+		execPath := filepath.Join(getAppName(), "Contents", "MacOS", APPNAME)
+		darwinStripBinary(execPath, getAppName()+".dSYM")
 
 		// strip test binary
 		if buildTestFlag {
-			darwinStripBinary(filepath.Join(buildDir, "yass_test"), "yass_test.dSYM")
+			darwinStripBinary("yass_test", "yass_test.dSYM")
 		}
 		// strip benchmark binary
 		if buildBenchmarkFlag {
-			darwinStripBinary(filepath.Join(buildDir, "yass_benchmark"), "yass_benchmark.dSYM")
+			darwinStripBinary("yass_benchmark", "yass_benchmark.dSYM")
 		}
 	} else if systemNameFlag == "ios" {
 		// strip main binary
-		execPath := filepath.Join(buildDir, getAppName(), "Contents", "MacOS", APPNAME)
-		darwinStripBinary(execPath, APPNAME+".dSYM")
+		execPath := filepath.Join(getAppName(), "Contents", "MacOS", APPNAME)
+		darwinStripBinary(execPath, getAppName()+".dSYM")
 	} else {
 		glog.Warningf("strip operation not implemented in platform %s", systemNameFlag)
 	}


### PR DESCRIPTION
I don't know why the debuginfo uploaded by github actions upload artificates misses dwo files. This patch will revert back to previous behavior.