### PR TITLE
gh actions: re-enable mold linker for loongarch64 (linux)

### DIFF
--- a/.github/workflows/releases-linux-binary.yml
+++ b/.github/workflows/releases-linux-binary.yml
@@ -82,7 +82,7 @@ jobs:
           - arch: loongarch64
             build_type: Release
             qemu_suffix: loongarch64
-            build_options: -use-allocator=tcmalloc
+            build_options: -use-allocator=tcmalloc -use-mold -enable-lto=false
           - arch: riscv64
             build_type: Release
             qemu_suffix: riscv64

--- a/third_party/ca-certificates/ca-bundle.crt.S
+++ b/third_party/ca-certificates/ca-bundle.crt.S
@@ -5,11 +5,12 @@
 .hidden _z_binary_ca_bundle_crt_end
 .global _z_binary_ca_bundle_crt_end
 .type   _z_binary_ca_bundle_crt_end, %object
-.align  4
 
+.align  4
 _z_binary_ca_bundle_crt_start:
 .incbin "ca-bundle.crt.zlib"
 
+.align  4
 _z_binary_ca_bundle_crt_end:
 .previous
 

--- a/third_party/ca-certificates/ca-bundle.crt.apple.s
+++ b/third_party/ca-certificates/ca-bundle.crt.apple.s
@@ -3,10 +3,11 @@
 .global __z_binary_ca_bundle_crt_start
 .private_extern __z_binary_ca_bundle_crt_end
 .global __z_binary_ca_bundle_crt_end
-.p2align  6
 
+.p2align  4
 __z_binary_ca_bundle_crt_start:
 .incbin "ca-bundle.crt.zlib"
 
+.p2align  4
 __z_binary_ca_bundle_crt_end:
 .previous

--- a/third_party/ca-certificates/ca-bundle.crt.asm
+++ b/third_party/ca-certificates/ca-bundle.crt.asm
@@ -8,6 +8,7 @@ __z_binary_ca_bundle_crt_start:
 ALIGN 4
 incbin "ca-bundle.crt.zlib"
 __z_binary_ca_bundle_crt_end:
+ALIGN 4
 %else
 global _z_binary_ca_bundle_crt_start
 global _z_binary_ca_bundle_crt_end
@@ -17,4 +18,5 @@ _z_binary_ca_bundle_crt_start:
 ALIGN 4
 incbin "ca-bundle.crt.zlib"
 _z_binary_ca_bundle_crt_end:
+ALIGN 4
 %endif

--- a/third_party/ca-certificates/ca-bundle.crt.win.s
+++ b/third_party/ca-certificates/ca-bundle.crt.win.s
@@ -1,9 +1,10 @@
 .section .rdata
 .global _z_binary_ca_bundle_crt_start
 .global _z_binary_ca_bundle_crt_end
-.align  4
 
+.align  4
 _z_binary_ca_bundle_crt_start:
 .incbin "ca-bundle.crt.zlib"
 
+.align  4
 _z_binary_ca_bundle_crt_end:

--- a/third_party/ca-certificates/supplementary-ca-bundle.crt.S
+++ b/third_party/ca-certificates/supplementary-ca-bundle.crt.S
@@ -5,11 +5,12 @@
 .hidden _z_binary_supplementary_ca_bundle_crt_end
 .global _z_binary_supplementary_ca_bundle_crt_end
 .type   _z_binary_supplementary_ca_bundle_crt_end, %object
-.align  4
 
+.align  4
 _z_binary_supplementary_ca_bundle_crt_start:
 .incbin "supplementary-ca-bundle.crt.zlib"
 
+.align  4
 _z_binary_supplementary_ca_bundle_crt_end:
 .previous
 

--- a/third_party/ca-certificates/supplementary-ca-bundle.crt.apple.s
+++ b/third_party/ca-certificates/supplementary-ca-bundle.crt.apple.s
@@ -3,10 +3,11 @@
 .global __z_binary_supplementary_ca_bundle_crt
 .private_extern __z_binary_supplementary_ca_bundle_crt_end
 .global __z_binary_supplementary_ca_bundle_crt_end
-.p2align  6
 
+.p2align  4
 __z_binary_supplementary_ca_bundle_crt_start:
 .incbin "supplementary-ca-bundle.crt.zlib"
 
+.p2align  4
 __z_binary_supplementary_ca_bundle_crt_end:
 .previous

--- a/third_party/ca-certificates/supplementary-ca-bundle.crt.asm
+++ b/third_party/ca-certificates/supplementary-ca-bundle.crt.asm
@@ -8,6 +8,7 @@ __z_binary_supplementary_ca_bundle_crt_start:
 ALIGN 4
 incbin "supplementary-ca-bundle.crt.zlib"
 __z_binary_supplementary_ca_bundle_crt_end:
+ALIGN 4
 %else
 global _z_binary_supplementary_ca_bundle_crt_start
 global _z_binary_supplementary_ca_bundle_crt_end
@@ -17,4 +18,5 @@ _z_binary_supplementary_ca_bundle_crt_start:
 ALIGN 4
 incbin "supplementary-ca-bundle.crt.zlib"
 _z_binary_supplementary_ca_bundle_crt_end:
+ALIGN 4
 %endif

--- a/third_party/ca-certificates/supplementary-ca-bundle.crt.win.s
+++ b/third_party/ca-certificates/supplementary-ca-bundle.crt.win.s
@@ -1,9 +1,10 @@
 .section .rdata
 .global _z_binary_supplementary_ca_bundle_crt_start
 .global _z_binary_supplementary_ca_bundle_crt_end
-.align  4
 
+.align  4
 _z_binary_supplementary_ca_bundle_crt_start:
 .incbin "supplementary-ca-bundle.crt.zlib"
 
+.align  4
 _z_binary_supplementary_ca_bundle_crt_end:


### PR DESCRIPTION
Through the fix doesn't work with nasm:

```
CMakeFiles/asio_supplementary_ca_bundle_crt.dir/third_party/ca-certificates/supplementary-ca-bundle.crt.asm.obj:
00000000 a .absolut
00000c42 R _z_binary_supplementary_ca_bundle_crt_end
00000000 R _z_binary_supplementary_ca_bundle_crt_start

CMakeFiles/asio_ca_bundle_crt.dir/third_party/ca-certificates/ca-bundle.crt.asm.obj:
00000000 a .absolut
0001ee93 R _z_binary_ca_bundle_crt_end
00000000 R _z_binary_ca_bundle_crt_start
```